### PR TITLE
Fix docker-compose.yaml volume bindings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,10 @@ services:
     ports:
       - "443:443"
     volumes:
-      - $PWD/Caddyfile:/etc/caddy/Caddyfile
-      - $PWD/sites:/usr/share/caddy
-      - $PWD/caddy_data:/data
-      - $PWD/caddy_config:/config
+      - type: bind
+        source: './Caddyfile'
+        target: /etc/caddy/Caddyfile
+        read_only: true
+      - ./sites:/usr/share/caddy
+      - ./caddy_data:/data
+      - ./caddy_config:/config


### PR DESCRIPTION
The current volume definitions didn't work for me. In particular, $PWD didn't work, and it tried to bind a directory at `/etc/caddy/Caddyfile/` (which failed because `./Caddyfile` is a file not a dir).

This configuration works for me running docker in WSL2, but I'm unsure if this works just as well in other environments.